### PR TITLE
Fix mouse cursor offset in remote browser view.

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -23,8 +23,8 @@ wsInput.onmessage = (msg) => {
 };
 
 function sendMouseEvent(type, e, clickCount = 1) {
-  const scaleX = remoteWidth / canvas.width / zoomFactor;
-  const scaleY = remoteHeight / canvas.height / zoomFactor;
+  const scaleX = remoteWidth / canvas.width;
+  const scaleY = remoteHeight / canvas.height;
 
   const rx = e.offsetX * scaleX;
   const ry = e.offsetY * scaleY;


### PR DESCRIPTION
The remote mouse cursor (red dot) was being drawn at an incorrect position, offset from the actual cursor. This was due to an error in the coordinate scaling logic in `public/client.js`.

The `zoomFactor` from the remote Electron window was being incorrectly applied, causing the calculated coordinates to be divided by the zoom factor, leading to the visual offset.

This commit corrects the scaling logic by removing the division by `zoomFactor`. This ensures that:
1. The mouse input events sent to the remote window have correctly scaled physical coordinates.
2. The local representation of the remote cursor is drawn at the correct position on the canvas, aligning with the user's actual cursor.