### PR TITLE
fix: Resolve cursor offset by removing H1 and adjusting draw logic

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,6 @@
   </style>
 </head>
 <body>
-<h1>网页里的远程 Electron 浏览器</h1>
 <canvas id="browser"></canvas>
 
 <!-- 引入鼠标与交互逻辑 -->


### PR DESCRIPTION
This commit applies a two-part fix to resolve a persistent issue where the remote cursor representation (a red cross) was visually offset.

1.  **Remove H1 Title:** The `<h1>` element in `index.html` was removed. This element appeared to be a contributing factor to the coordinate offset issue.

2.  **Adjust Drawing Calculation:** The cursor drawing logic in `client.js` was modified to correctly multiply the calculated coordinates by the `zoomFactor`. This ensures the cursor's visual position on the canvas is correctly scaled.

After a long debugging process, this combination of changes was found to correctly position the cursor.