### PR TITLE
feat: Replace red cross with a themed mouse cursor

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -106,12 +106,16 @@ wsFrame.onmessage = (msg) => {
       if (remoteMouse.x >= 0) {
         const cx = remoteMouse.x * (canvas.width / remoteWidth) * zoomFactor;
         const cy = remoteMouse.y * (canvas.height / remoteHeight) * zoomFactor;
-        ctx.strokeStyle = "red";
+        // Draw a mouse cursor icon
         ctx.beginPath();
-        ctx.moveTo(cx - 5, cy);
-        ctx.lineTo(cx + 5, cy);
-        ctx.moveTo(cx, cy - 5);
-        ctx.lineTo(cx, cy + 5);
+        ctx.moveTo(cx, cy);
+        ctx.lineTo(cx, cy + 16);
+        ctx.lineTo(cx + 11, cy + 11);
+        ctx.closePath();
+        ctx.fillStyle = "white";
+        ctx.fill();
+        ctx.strokeStyle = "black";
+        ctx.lineWidth = 1;
         ctx.stroke();
       }
     };


### PR DESCRIPTION
This commit introduces a new feature based on user request to provide a "built-in" mouse cursor instead of the red crosshair.

Changes include:
- The drawing logic in `public/client.js` is updated to render a standard arrow-shaped mouse pointer on the canvas.
- This commit also includes the cumulative fixes from the previous debugging session that resolved the cursor's positional offset, ensuring this new icon is rendered in the correct location. This includes a correction to the drawing calculation and the removal of a layout-interfering `<h1>` element from `public/index.html`.